### PR TITLE
Add configurable Livox multi-LiDAR launch file with runtime IP validation

### DIFF
--- a/config/multi_lidar.json
+++ b/config/multi_lidar.json
@@ -1,0 +1,56 @@
+{
+  "lidar_summary_info" : {
+    "lidar_type": 8
+  },
+  "MID360": {
+    "lidar_net_info" : {
+      "cmd_data_port": 56100,
+      "push_msg_port": 56200,
+      "point_data_port": 56300,
+      "imu_data_port": 56400,
+      "log_data_port": 56500
+    },
+    "host_net_info" : {
+      "cmd_data_ip" : "192.168.1.50",
+      "cmd_data_port": 56101,
+      "push_msg_ip": "192.168.1.50",
+      "push_msg_port": 56201,
+      "point_data_ip": "192.168.1.50",
+      "point_data_port": 56301,
+      "imu_data_ip" : "192.168.1.50",
+      "imu_data_port": 56401,
+      "log_data_ip" : "",
+      "log_data_port": 56501
+    }
+  },
+  "lidar_configs" : [
+    {
+      "ip" : "192.168.1.128",
+      "pcl_data_type" : 1,
+      "pattern_mode" : 0,
+      "frame_id" : "front_lidar_link",
+      "extrinsic_parameter" : {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    {
+      "ip" : "192.168.1.123",
+      "pcl_data_type" : 1,
+      "pattern_mode" : 0,
+      "frame_id" : "back_lidar_link",
+      "extrinsic_parameter" : {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  ]
+}

--- a/launch/multi_lidar_launch.py
+++ b/launch/multi_lidar_launch.py
@@ -1,14 +1,17 @@
 import os
+import json
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from ament_index_python.packages import get_package_share_directory
+
 
 def generate_launch_description():
-    cur_path = os.path.split(os.path.realpath(__file__))[0]
-    cur_config_path = os.path.join(cur_path, '../config')
-    default_user_config = os.path.join(cur_config_path, 'multi_lidar_hunter.json')
-    rviz_config_path = os.path.join(cur_config_path, 'display_point_cloud_ROS2.rviz')
+    lidar_bringup_dir = get_package_share_directory('livox_ros_driver2')
+    default_user_config = os.path.join(lidar_bringup_dir, 'config', 'multi_lidar.json')
+    rviz_config_path = os.path.join(lidar_bringup_dir, 'config', 'display_point_cloud_ROS2.rviz')
 
     user_config_arg = DeclareLaunchArgument(
         'user_config_path',
@@ -16,31 +19,72 @@ def generate_launch_description():
         description='Path to Livox user configuration JSON file'
     )
 
-    livox_ros2_params = [
-        {"xfer_format": 0},
-        {"multi_topic": 1},
-        {"data_src": 0},
-        {"publish_freq": 10.0},
-        {"output_data_type": 0},
-        {"frame_id": 'livox_frame'},
-        {"lvx_file_path": '/home/livox/livox_test.lvx'},
-        {"user_config_path": LaunchConfiguration('user_config_path')},
-        {"cmdline_input_bd_code": 'livox0000000001'}
-    ]
-
-    livox_driver = Node(
-        package='livox_ros_driver2',
-        executable='livox_ros_driver2_node',
-        name='livox_lidar_publisher',
-        output='screen',
-        parameters=livox_ros2_params,
-        remappings=[
-            ("/livox/lidar_192_168_1_102", "/front_lidar/points"),
-            ("/livox/lidar_192_168_1_130", "/back_lidar/points")
-        ]
+    visualize_arg = DeclareLaunchArgument(
+        'visualize',
+        default_value='false',
+        description='Enable RViz visualization'
     )
+
+    def launch_setup(context, *args, **kwargs):
+        config_path = LaunchConfiguration('user_config_path').perform(context)
+
+        if not os.path.exists(config_path):
+            raise RuntimeError(f"Config file not found: {config_path}")
+
+        try:
+            with open(config_path, 'r') as f:
+                cfg = json.load(f)
+                lidar_entries = cfg.get("lidar_configs", [])
+        except Exception as e:
+            raise RuntimeError(f"Failed to read or parse config: {e}")
+
+        if len(lidar_entries) < 2:
+            raise RuntimeError(f"Expected at least 2 lidar entries, found {len(lidar_entries)}")
+
+        ips = [lidar["ip"] for lidar in lidar_entries]
+        if not all(ips):
+            raise RuntimeError("One or more lidar entries have no 'ip' field defined")
+
+        ips_safe = [ip.replace('.', '_') for ip in ips]
+        front_ip = ips_safe[0]
+        back_ip = ips_safe[1]
+
+        livox_ros2_params = [
+            {"xfer_format": 0}, # 0-Pointcloud2(PointXYZRTL), 1-customized pointcloud format
+            {"multi_topic": 1}, # 0-All LiDARs share the same topic, 1-One LiDAR one topic
+            {"data_src": 0},    # 0-lidar, others-Invalid data src
+            {"publish_freq": 10.0}, # frequency of publish, 5.0, 10.0, 20.0, 50.0, etc.
+            {"output_data_type": 0},
+            {"frame_id": 'livox_frame'},
+            {"lvx_file_path": '/home/livox/livox_test.lvx'},
+            {"user_config_path": config_path},
+            {"cmdline_input_bd_code": 'livox0000000001'}
+        ]
+
+        livox_driver = Node(
+            package='livox_ros_driver2',
+            executable='livox_ros_driver2_node',
+            name='livox_lidar_publisher',
+            output='screen',
+            parameters=livox_ros2_params,
+            remappings=[
+                (f"/livox/lidar_{front_ip}", "/front_lidar/points"),
+                (f"/livox/lidar_{back_ip}", "/back_lidar/points")
+            ]
+        )
+
+        rviz_node = Node(
+            package="rviz2",
+            executable="rviz2",
+            output="screen",
+            arguments=["-d", rviz_config_path],
+            condition=IfCondition(LaunchConfiguration("visualize")),
+        )
+
+        return [livox_driver, rviz_node]
 
     return LaunchDescription([
         user_config_arg,
-        livox_driver,
+        visualize_arg,
+        OpaqueFunction(function=launch_setup)
     ])

--- a/launch/multi_lidar_launch.py
+++ b/launch/multi_lidar_launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
         if len(lidar_entries) < 2:
             raise RuntimeError(f"Expected at least 2 lidar entries, found {len(lidar_entries)}")
 
-        ips = [lidar["ip"] for lidar in lidar_entries]
+        ips = [lidar.get("ip") for lidar in lidar_entries]
         if not all(ips):
             raise RuntimeError("One or more lidar entries have no 'ip' field defined")
 

--- a/launch/multi_lidar_launch.py
+++ b/launch/multi_lidar_launch.py
@@ -1,0 +1,46 @@
+import os
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument
+
+def generate_launch_description():
+    cur_path = os.path.split(os.path.realpath(__file__))[0]
+    cur_config_path = os.path.join(cur_path, '../config')
+    default_user_config = os.path.join(cur_config_path, 'multi_lidar_hunter.json')
+    rviz_config_path = os.path.join(cur_config_path, 'display_point_cloud_ROS2.rviz')
+
+    user_config_arg = DeclareLaunchArgument(
+        'user_config_path',
+        default_value=default_user_config,
+        description='Path to Livox user configuration JSON file'
+    )
+
+    livox_ros2_params = [
+        {"xfer_format": 0},
+        {"multi_topic": 1},
+        {"data_src": 0},
+        {"publish_freq": 10.0},
+        {"output_data_type": 0},
+        {"frame_id": 'livox_frame'},
+        {"lvx_file_path": '/home/livox/livox_test.lvx'},
+        {"user_config_path": LaunchConfiguration('user_config_path')},
+        {"cmdline_input_bd_code": 'livox0000000001'}
+    ]
+
+    livox_driver = Node(
+        package='livox_ros_driver2',
+        executable='livox_ros_driver2_node',
+        name='livox_lidar_publisher',
+        output='screen',
+        parameters=livox_ros2_params,
+        remappings=[
+            ("/livox/lidar_192_168_1_102", "/front_lidar/points"),
+            ("/livox/lidar_192_168_1_130", "/back_lidar/points")
+        ]
+    )
+
+    return LaunchDescription([
+        user_config_arg,
+        livox_driver,
+    ])


### PR DESCRIPTION
This PR introduces a new launch file for `livox_ros_driver2` that supports dynamic configuration of multiple Livox LiDARs through a JSON configuration file.
The launch script now reads LiDAR IP addresses directly from the provided `user_config_path` and automatically generates appropriate topic remappings.

If the configuration file is invalid, missing, or does not include the expected IP fields, the launch process fails immediately with a clear error message—preventing silent misconfiguration or incorrect topic bindings.

---

### **Key Features**

* **Dynamic IP detection:**
  Reads all LiDAR IPs from the `lidar_configs` array in the provided JSON file.
  Each IP is automatically converted to ROS-safe topic names (dots replaced with underscores).

* **Strict validation:**
  Launch fails if:

  * The config file cannot be found or parsed
  * Fewer than two LiDARs are defined
  * Any LiDAR entry is missing an `ip` field

* **No default fallbacks:**
  Removes all hardcoded IP defaults (`192_168_1_102`, `192_168_1_130`).
  The configuration file is now the single source of truth.

* **Launch arguments:**

  * `user_config_path` → path to the JSON config file
  * `visualize` → optional boolean to enable RViz

* **Automatic remappings:**
  Builds topic remaps dynamically:

  ```
  /livox/lidar_<ip>  →  /<front|back>_lidar/points
  ```

* **Fail-fast behavior:**
  Any configuration error raises a `RuntimeError` before node execution begins.

---

### **Usage Example**

```bash
ros2 launch livox_ros_driver2 multi_lidar_launch.py \
  user_config_path:=/path/to/multi_lidar.json 
```

---

### **Files Added**

* `launch/multi_lidar_launch.py`

---

### **Testing**

* Verified with valid and invalid configuration files.
* Confirmed correct topic remappings for both LiDARs.
* Verified immediate failure for missing or malformed IP definitions.

